### PR TITLE
Fix compilation issue with gcc14 or newer

### DIFF
--- a/cpp/cpp.h
+++ b/cpp/cpp.h
@@ -91,6 +91,7 @@ enum errtype { WARNING, ERROR, FATAL };
 void	expandlex(void);
 void	fixlex(void);
 void	setup(int, char **);
+void    setup_kwtab();
 int	gettokens(Tokenrow *, int);
 int	comparetokens(Tokenrow *, Tokenrow *);
 Source	*setsource(char *, FILE *, char *);


### PR DESCRIPTION
Compilation with GCC14 or newer would yield following error:

```
$ gcc --version
gcc (GCC) 14.2.1 20240912 (Red Hat 14.2.1-3)
Copyright (C) 2024 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

$ make -j256
gcc -O2 -Wall -fno-strict-aliasing -MMD -c -Icpp -o build--/cpp/unix.o cpp/unix.c
cpp/unix.c: In function ‘setup’:
cpp/unix.c:32:9: error: implicit declaration of function ‘setup_kwtab’ [-Wimplicit-function-declaration]
   32 |         setup_kwtab();
      |         ^~~~~~~~~~~
make: *** [Makefile:127: build--/cpp/unix.o] Error 1
Exit 2
```

